### PR TITLE
Added Parse File Upload Testing

### DIFF
--- a/ascension/src/layouts/AdminPage.vue
+++ b/ascension/src/layouts/AdminPage.vue
@@ -52,7 +52,7 @@
     <span>Badge Points: </span>
     <input v-model="BadgePoints" type="number"><br>
     <span>Badge Image </span>
-    <input v-model="BadgeImage" type="text"><br>
+    <input @change="onBadgeImageSelected" type="file" name="img" accept="image/x-png,image/gif,image/jpeg"/><br>
     <button @click="addBadge()">Add Badge</button><br>
 
     <h3>Edit / Delete Badge</h3>
@@ -376,17 +376,28 @@
             },
 
             //Badges Functions
-            //Testing! add other necessarry attributes
             async addBadge(){
-                this.ShowBadges = false
+                this.ShowBadges = false;
                 var params = {
                     "BadgeName" : this.BadgeName,
                     "BadgeDescription" : this.BadgeDescription,
                     "BadgePoints" : this.BadgePoints,
-                    "BadgeImage" : this.BadgeImage,
+                    "BadgeImage" : "",
                 }
-                await Parse.Cloud.run("AddBadge", params);
-                alert("Added Badge");
+                //Save file in parse, then get the result (Having errors if transfered in parse code)
+                var file = this.BadgeImage;
+                var name = this.BadgeImage.name;
+                var parseFile = new Parse.File(name, file);
+                parseFile.save().then(async(res) => {
+                    // The file has been saved to Parse.
+                    params["BadgeImage"] = res.url();
+                    await Parse.Cloud.run("AddBadge", params);
+                    alert("Added Badge");
+                });
+            },
+
+            onBadgeImageSelected(e){
+                this.BadgeImage = e.target.files[0];
             },
 
             async editBadge(){

--- a/parse-server-ascension/cloud/badge.js
+++ b/parse-server-ascension/cloud/badge.js
@@ -1,7 +1,3 @@
-/*
-    Functions that are not yet tested upon creating/updating:
-    - DeleteBadge
-*/
 var Global = require('./global');
 
 Parse.Cloud.define("AddBadge", async(request) => {
@@ -9,11 +5,25 @@ Parse.Cloud.define("AddBadge", async(request) => {
     const badge = new Badge();
     const argument = request.params;
 
+    /*
+    - Tried uploading the file in parsecode before adding badge, but did not work
+    - argument.BadgeImage should be the file (e.target.files[0])
+    var convertedImage = {base64: argument.BadgeImage.toString('base64')}; //needs to be base64 before uploading to parse file, in retrieving, there will be a url/link
+    var parseFile = new Parse.File(argument.BadgeImage.name, convertedImage);
+    var link;
+
+    - how to get url
+    parseFile.save().then(function(res) {
+        link = res.url();
+    });
+    - ParseError: File upload by public is disabled (code 130)
+    */
+
     badge.save({
         "BadgeName" : argument.BadgeName,
         "BadgeDescription" : argument.BadgeDescription,
         "BadgePoints" : argument.BadgePoints,
-        "BadgeImage" : argument.BadgeImage,
+        "BadgeImage" : argument.BadgeImage, //parseFile -> does not work(read comment above)
     }).then(()=>{
         console.log("Successfully added Badge!");
     });
@@ -95,6 +105,13 @@ Parse.Cloud.define("DeleteBadge", async(request) => {
             }
         }
     }
+    /*
+    This does not work
+    //Delete image
+    var imageToDelete = res.get("BadgeImage");
+    param = {"url" : imageToDelete};
+    await Parse.Cloud.run("DeleteFile", param); -> function is in function.js
+    */
 
     res.destroy().then(async()=>{
         console.log("Badge has been deleted!");

--- a/parse-server-ascension/cloud/functions.js
+++ b/parse-server-ascension/cloud/functions.js
@@ -7,7 +7,7 @@ Parse.Cloud.define("GoogleSignIn", async (request) => {
     const oauth2Client = new OAuth2(
       "762534465467-srl15os6nbsoaqr89aekvicok61tildv.apps.googleusercontent.com",
       "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",
-      ["http://localhost:8080/RedirectPage"],
+      ["http://localhost:8088/RedirectPage"],
     );
     // Obtain the google login link to which we'll send our users to give us access
     const loginLink = oauth2Client.generateAuthUrl({
@@ -29,7 +29,7 @@ Parse.Cloud.define("GoogleToken", async (request) => {
     const oauth2Client = new OAuth2(
         "762534465467-srl15os6nbsoaqr89aekvicok61tildv.apps.googleusercontent.com",
         "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",
-        ["http://localhost:8080/RedirectPage"],
+        ["http://localhost:8088/RedirectPage"],
     );
   
     if (request.error) {
@@ -57,4 +57,17 @@ Parse.Cloud.define("GoogleToken", async (request) => {
         return error;
       }
     }
+});
+
+//Does not work
+Parse.Cloud.define("DeleteFile", async(request) =>{
+  const argument = request.params;
+  await Parse.Cloud.httpRequest({
+    url: argument.url,
+    method: 'DELETE',
+    headers: {
+        'X-Parse-Master-Key' : 'master',
+        'X-Parse-Application-Id': 'myAppId'
+    }
+  });
 });

--- a/parse-server-ascension/cloud/student.js
+++ b/parse-server-ascension/cloud/student.js
@@ -22,13 +22,14 @@ Parse.Cloud.define("AddStudent", async(request) => {
     }).then(async (res)=>{
         console.log("Successfully added Student!");
         /*
-        This is not working, unable to edit user data
+            Does not work
+            const query = new Parse.Query(Parse.User);
+            query.equalTo("objectId", argument.UserID);
+            const res2 = await query.first({useMasterKey:true});
+            res2.set("AccountID", res.id);
+            res2.save({useMasterKey:true});
 
-        const query = new Parse.Query(Parse.User);
-        query.equalTo(argument.UserID, argument.StudentID);
-        const res2 = await query.find({useMasterKey:true});
-        res2.set("AccountID", res.id);
-        res2.save({useMasterKey:true});
+            - ParseError: Cannot modify user jBDrWWWDMs (code 206)
         */
     });
 });


### PR DESCRIPTION
Added Parse File Upload Testing
= Badges can now store image urls on BadgeImage attribute
= Need more research in this, since saving file should be on cloud functions (refer in admin.vue and badge.js, addBadge function)
= Cannot delete the files uploaded on Parse File (refer deletefile function in function.js)

functions.js
- changed redirect page port to 8088
- added deletefile function (currently not working)

student.js
- commented error info and code in addstudent function

badge.js
- commented error info and code in addbadge function
- commented calling deleteFile in deletebadge function

Admin.vue
- Changed BadgeImage to file upload
- Edited AddBadge function